### PR TITLE
Support GDAL v3.6 #36

### DIFF
--- a/gdal/reflectance/base.cpp
+++ b/gdal/reflectance/base.cpp
@@ -8,11 +8,19 @@ using namespace std;
 namespace msat {
 namespace utils {
 
+ProxyDataset::~ProxyDataset() {
+    delete osr;
+}
+
 void ProxyDataset::add_info(GDALDataset* ds, const std::string& dsname)
 {
-    const char* proj = ds->GetProjectionRef();
-    if (!proj)
+    const OGRSpatialReference* osr_tmp = ds->GetSpatialRef();
+    if (!osr_tmp)
         throw std::runtime_error(dsname + ": trying to add source without a projection definition");
+    char* p;
+    osr_tmp->exportToWkt(&p);
+    const std::string proj(p);
+    CPLFree(p);
 
     double gt[6];
     if (ds->GetGeoTransform(gt) == CE_Failure)
@@ -21,10 +29,12 @@ void ProxyDataset::add_info(GDALDataset* ds, const std::string& dsname)
     const char* mdtime = ds->GetMetadataItem(MD_MSAT_DATETIME, MD_DOMAIN_MSAT);
     if (mdtime == nullptr)
         throw std::runtime_error(dsname + ": trying to add source without " MD_DOMAIN_MSAT "/" MD_MSAT_DATETIME " metadata");
-
     if (!has_sources)
     {
         projection_ref = proj;
+        if (osr)
+            delete osr;
+        osr = osr_tmp->Clone();
         memcpy(geotransform, gt, 6 * sizeof(double));
         char** metadata = ds->GetMetadata(MD_DOMAIN_MSAT);
         if (metadata == nullptr)
@@ -57,11 +67,8 @@ const char* ProxyDataset::GetProjectionRef()
     return projection_ref.c_str();
 }
 #else
-const char* ProxyDataset::_GetProjectionRef() {
-    return projection_ref.c_str();
-}
 const OGRSpatialReference* ProxyDataset::GetSpatialRef() const {
-    return GetSpatialRefFromOldGetProjectionRef();
+    return osr;
 }
 #endif
 

--- a/gdal/reflectance/base.h
+++ b/gdal/reflectance/base.h
@@ -12,6 +12,7 @@ class ProxyDataset : public GDALDataset
 {
 protected:
     std::string projection_ref;
+    OGRSpatialReference* osr = nullptr;
 
 public:
     /// True when at least one source has been added
@@ -23,6 +24,8 @@ public:
     /// Datetime metadata string
     std::string datetime;
 
+    ~ProxyDataset();
+
     /**
      * Add information from the given dataset, raising an exception if they are
      * inconsistent with previously added ones.
@@ -32,7 +35,6 @@ public:
 #if GDAL_VERSION_MAJOR < 3
     const char* GetProjectionRef() override;
 #else
-    const char* _GetProjectionRef() override;
     const OGRSpatialReference* GetSpatialRef() const override;
 #endif
     CPLErr GetGeoTransform(double* tr) override;

--- a/gdal/reflectance/pixeltolatlon.cpp
+++ b/gdal/reflectance/pixeltolatlon.cpp
@@ -11,11 +11,11 @@ PixelToLatlon::PixelToLatlon(GDALDataset* ds)
     if (ds->GetGeoTransform(geoTransform) != CE_None)
         throw std::runtime_error("no geotransform found in input dataset");
 
-    const char* projname = ds->GetProjectionRef();
-    if (!projname || !projname[0])
+    const OGRSpatialReference* osr = ds->GetSpatialRef();
+    if (!osr)
         throw std::runtime_error("no projection name found in input dataset");
 
-    proj = new OGRSpatialReference(projname);
+    proj = osr->Clone();
     latlon = proj->CloneGeogCS();
     toLatLon = OGRCreateCoordinateTransformation(proj, latlon);
 #if GDAL_VERSION_MAJOR >= 3

--- a/gdal/xrit/dataset.cpp
+++ b/gdal/xrit/dataset.cpp
@@ -17,18 +17,18 @@ XRITDataset::XRITDataset(const xrit::FileAccess& fa)
 {
 }
 
+XRITDataset::~XRITDataset() {
+    delete osr;
+}
+
 #if GDAL_VERSION_MAJOR < 3
 const char* XRITDataset::GetProjectionRef()
 {
     return projWKT.c_str();
 }
 #else
-const char* XRITDataset::_GetProjectionRef() {
-    return projWKT.c_str();
-}
-
 const OGRSpatialReference* XRITDataset::GetSpatialRef() const {
-    return GetSpatialRefFromOldGetProjectionRef();
+    return osr;
 }
 #endif
 
@@ -76,7 +76,7 @@ bool XRITDataset::init()
 
     /// Projection
     projWKT = dataset::spaceviewWKT(header.image_navigation->subsatellite_longitude);
-
+    osr = new OGRSpatialReference(projWKT.c_str());
 
     /// Geotransform matrix
     double pixelSizeX, pixelSizeY;

--- a/gdal/xrit/dataset.h
+++ b/gdal/xrit/dataset.h
@@ -11,21 +11,23 @@ namespace xrit {
 
 class XRITDataset : public GDALDataset
 {
+protected:
+    std::string projWKT;
 public:
     xrit::FileAccess fa;
     xrit::DataAccess da;
     int spacecraft_id;
-    std::string projWKT;
     double geotransform[6];
+    OGRSpatialReference* osr = nullptr;
 
     XRITDataset(const xrit::FileAccess& fa);
+    ~XRITDataset();
 
     virtual bool init();
 
 #if GDAL_VERSION_MAJOR < 3
     virtual const char* GetProjectionRef() override;
 #else
-    const char* _GetProjectionRef() override;
     const OGRSpatialReference* GetSpatialRef() const override;
 #endif
     virtual CPLErr GetGeoTransform(double* tr);

--- a/msat/gdal/dataset.cpp
+++ b/msat/gdal/dataset.cpp
@@ -196,16 +196,14 @@ CPLErr GeoReferencer::init(GDALDataset* ds)
 	CPLErr res = invertGeoTransform(geoTransform, invGeoTransform);
 	if (res != CE_None) return res;
 
-	const char* projname = ds->GetProjectionRef();
-	if (!projname || !projname[0])
+    const OGRSpatialReference* osr = ds->GetSpatialRef();
+	if (!osr)
 	{
 		CPLError(CE_Failure, CPLE_AppDefined, "no projection name found in input dataset");
 		return CE_Failure;
 	}
 
-	projection = projname;
-
-	proj = new OGRSpatialReference(projection.c_str());
+	proj = osr->Clone();
 	latlon = proj->CloneGeogCS();
 	toLatLon = OGRCreateCoordinateTransformation(proj, latlon);
 	fromLatLon = OGRCreateCoordinateTransformation(latlon, proj);
@@ -270,13 +268,12 @@ const char* ProxyDataset::GetMetadataItem(const char *pszName, const char *pszDo
 }
 
 #if GDAL_VERSION_MAJOR < 3
-const char* ProxyDataset::GetProjectionRef(void) { return ds.GetProjectionRef(); }
-#else
-const char* ProxyDataset::_GetProjectionRef() {
+const char* ProxyDataset::GetProjectionRef(void) {
     return ds.GetProjectionRef();
 }
+#else
 const OGRSpatialReference* ProxyDataset::GetSpatialRef() const {
-    return GetSpatialRefFromOldGetProjectionRef();
+    return ds.GetSpatialRef();
 }
 #endif
 CPLErr ProxyDataset::GetGeoTransform(double* d) { return ds.GetGeoTransform(d); }

--- a/msat/gdal/dataset.h
+++ b/msat/gdal/dataset.h
@@ -65,7 +65,6 @@ class GeoReferencer
 {
 protected:
 	GDALDataset* ds;
-	std::string projection;
 	double geoTransform[6];
 	double invGeoTransform[6];
 	OGRSpatialReference* proj;
@@ -126,7 +125,6 @@ public:
 #if GDAL_VERSION_MAJOR < 3
     virtual const char* GetProjectionRef(void) override;
 #else
-    const char* _GetProjectionRef() override;
     const OGRSpatialReference* GetSpatialRef() const override;
 #endif
     virtual CPLErr GetGeoTransform(double*);

--- a/tests/gdal/utils.cc
+++ b/tests/gdal/utils.cc
@@ -133,13 +133,11 @@ GeoReferencer::GeoReferencer(GDALDataset* ds)
 
     dataset::invertGeoTransform(geoTransform, invGeoTransform);
 
-    const char* projname = ds->GetProjectionRef();
-    if (!projname || !projname[0])
+    const OGRSpatialReference* osr = ds->GetSpatialRef();
+    if (!osr)
         throw std::runtime_error("no projection name found in input dataset");
 
-    projection = projname;
-
-    proj = new OGRSpatialReference(projection.c_str());
+    proj = osr->Clone();
     latlon = proj->CloneGeogCS();
     toLatLon = OGRCreateCoordinateTransformation(proj, latlon);
     fromLatLon = OGRCreateCoordinateTransformation(latlon, proj);

--- a/tests/gdal/utils.h
+++ b/tests/gdal/utils.h
@@ -66,7 +66,6 @@ class GeoReferencer
 {
 protected:
     GDALDataset* ds;
-    std::string projection;
     double geoTransform[6];
     double invGeoTransform[6];
     OGRSpatialReference* proj;


### PR DESCRIPTION
`_GetProjectionRef()` method has been removed for GDAL >= 3.

Fix #36.

